### PR TITLE
Update macos target

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_SKIP: cp36-*
 


### PR DESCRIPTION
Bumps the matrix macOS version to macOS 13 and macOS 14, macOS 11 support has been discontinued since 2023

With this change, we also build arm64 wheels. 

@lauri-codes, would it be possible to make a new release with the arm64 wheels included or upload the new arm64 wheels to the current release? Thank you!